### PR TITLE
Remove overlay scanline effect from styles

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -29,14 +29,6 @@ html, body {
 ::-webkit-scrollbar-track { background: var(--bg-dark); }
 ::-webkit-scrollbar-thumb { background-color: var(--neon-cyan); border-radius: 4px; border: 1px solid var(--bg-dark); }
 
-body::after {
-    content: "";
-    position: fixed; top: 0; left: 0; width: 100%; height: 100%;
-    pointer-events: none;
-    background: linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 0, 0, 0.15) 50%);
-    background-size: 100% 4px; opacity: 0.15; z-index: 9999;
-}
-
 #matrix-canvas {
     position: fixed;
     top: 0;


### PR DESCRIPTION
## Summary
- remove the `body::after` scanline overlay in `styles.css`

## Testing
- `git status --short`